### PR TITLE
feat: Support using page reference as target page.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -54,7 +54,10 @@ async function main() {
     }
 
     // trim surrounding [[]] from target in case it is a page reference
-    const targetPage = target.replace(/^(\[\[)(.*)(\]\])$/, "$2")
+    // and escape "
+    const targetPage = target
+      .replace(/^(\[\[)(.*)(\]\])$/, "$2")
+      .replace(/"/g, '\\"')
 
     // split properties by ":", remove any empty entries.
     const propertyNames = propertyNameList.split(":").map((prop) => prop.trim()).filter(prop => prop !== "")

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,9 @@ async function main() {
       return
     }
 
+    // trim surrounding [[]] from target in case it is a page reference
+    const targetPage = target.replace(/^(\[\[)(.*)(\]\])$/, "$2")
+
     // split properties by ":", remove any empty entries.
     const propertyNames = propertyNameList.split(":").map((prop) => prop.trim()).filter(prop => prop !== "")
 
@@ -73,7 +76,7 @@ async function main() {
       :where 
       [?p :block/original-name ?on]
       [?p :block/properties ?prop]
-      [(= ?on "${target}")]
+      [(= ?on "${targetPage}")]
     ]`
 
     console.debug(":query", query)


### PR DESCRIPTION
Using the autocompletion feature is quite convenient when typing the page name in the macro (e.g., `{{tags [[page name]]}`). But currently we cannot query the correct page if the input target is a page reference.

I added special logics to handle this case, and this is backward compatible and should not affect the original logic.