### PR TITLE
feat: Add a default style for built-in property "tags".

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -102,7 +102,7 @@ async function main() {
         if (propertyName in properties) {
           value = properties[propertyName]
           if (propertyName === "tags" && formatTemplate === undefined) {
-            const htmlTemplate = '<a data-ref="${pageName}" class="tag">#${pageName}</a>'
+            const htmlTemplate = '<a data-ref="${pageName}" class="tag" data-on-click="openPage">#${pageName}</a>'
             const separatorSpanTemplate = '<span> </span>'
             if (Array.isArray(value)) {
               value = `<div>${value.map((tag) => {
@@ -135,5 +135,17 @@ async function main() {
   })
 }
 
+const model = {
+  openPage: async (e: any) => {
+    const pageName = e.dataset.ref
+    if (pageName) {
+      const pageEntity = await logseq.Editor.getPage(pageName)
+      if (pageEntity) {
+        await logseq.Editor.scrollToBlockInPage(pageName, pageEntity.uuid)
+      }
+    }
+  }
+}
+
 // bootstrap the plugin
-logseq.ready(main).catch(console.error)
+logseq.ready(model, main).catch(console.error)

--- a/src/main.ts
+++ b/src/main.ts
@@ -101,6 +101,17 @@ async function main() {
         let value = "";
         if (propertyName in properties) {
           value = properties[propertyName]
+          if (propertyName === "tags" && formatTemplate === undefined) {
+            const htmlTemplate = '<a data-ref="${pageName}" class="tag">#${pageName}</a>'
+            const separatorSpanTemplate = '<span> </span>'
+            if (Array.isArray(value)) {
+              value = `<div>${value.map((tag) => {
+                return htmlTemplate.replaceAll("${pageName}", tag)
+              }).join(separatorSpanTemplate)}</div>`
+            } else {
+              value = htmlTemplate.replaceAll("${pageName}", value)
+            }
+          }
           template = template.replace(`$${propertyName}`, value)
         }
         console.info(propertyName, template)


### PR DESCRIPTION
Since the built-in tags property is important and we cannot reserve the '#' and '[[]]' when get the result using query, page references are converted into plain text, we cannot use this plugin to create a macro like: `"tags" "$1 {{renderer :lookup, $1, tags}}"`, which can show all tags when referencing a page. In my workflow, this is quite useful when writing daily journals. So I've added a default tag style (same as which Logseq provided) when the user does not specify the template. The logic should be backward compatible and does not affect the original workflow.